### PR TITLE
翻译 RunTestsOptions.exitOnFail

### DIFF
--- a/lib.deno.ns.d.ts
+++ b/lib.deno.ns.d.ts
@@ -113,8 +113,11 @@ declare namespace Deno {
   }
 
   export interface RunTestsOptions {
-    /** If `true`, Deno will exit with status code 1 if there was
-     * test failure. Defaults to `true`. */
+    /**
+     * 如果为 `true`，当测试失败时 Deno 将以状态码 1 退出。
+     *
+     * 默认为 `true`。
+     */
     exitOnFail?: boolean;
     /** If `true`, Deno will exit upon first test failure. Defaults to `false`. */
     failFast?: boolean;


### PR DESCRIPTION
这是一个示例性质的翻译。目的是避免一些开发者的翻译腔。

什么是翻译腔呢？就像这样：

> 嘿，我的老伙计，真是见鬼。刚才有个可怜的小家伙问我什么是翻译腔。我敢打赌，他一定没翻译过英文文档。我的上帝，他提出的这个问题真的是太糟糕了，就像隔壁苏珊婶婶做的苹果派一样。

比如关于 `RunTestsOptions.exitOnFail` 的翻译。我们先看原文：

> If `true`, Deno will exit with status code 1 if there was test failure.

如果我们逐句翻译：

> 如果为 `true`，如果测试失败，Deno 将以状态码 1 退出。

很显然这是直接把 “if“ 翻译成了“如果”，导致句子很拗口。我们应该使用更加符合中国人的愈发语法习惯来翻译这句话：

> 如果为 `true`，当测试失败时 Deno 将以状态码 1 退出。

或者

> 如果为 `true`，当测试失败时 Deno 将会退出，状态码为 1。

当状语从句或者补语非常长时，第二种翻译更加适合。